### PR TITLE
Error handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,78 @@ record B(String s) {
 enum C { C1, C2 }
 ```
 
+### Array of Sources
+
+```typescript
+import { readFileSync } from "node:fs";
+import { parse } from "java-model";
+
+const files = ["input.java"];
+const sources = files.map((file) => readFileSync(file, "utf8"));
+const project = parse(sources);
+
+project.visitTypes((type) => {
+   console.log(type.name);
+   console.log(type.qualifiedName);
+   console.log(type.properties());
+});
+```
+
+### Provide a Read Function
+
 ```typescript
 import { readFileSync } from "node:fs";
 import { parse } from "java-model";
 
 const project = parse({
     files: ["input.java"],
-    read: (file) => readFileSync(file, "utf8")
+    read: file => readFileSync(file, "utf8")
 });
 
-project.visitTypes((type) => {
+project.visitTypes(type => {
    console.log(type.name);
    console.log(type.qualifiedName);
    console.log(type.properties());
+});
+```
+
+### Provide an Async Read Function
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { parse } from "java-model";
+
+const project = parse({
+    files: ["input.java"],
+    readAsync: file => readFile(file, "utf8")
+});
+
+project.visitTypes(type => {
+   console.log(type.name);
+   console.log(type.qualifiedName);
+   console.log(type.properties());
+});
+```
+
+### Error Handling
+
+On both handlers, readErrorHandler and parseErrorHandler, you can throw an error, or ignore it.
+Ignoring the error will omit the file from the project.
+Throwing an error will stop the parsing process.
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { parse } from "java-model";
+
+const project = parse({
+    files: ["input.java"],
+    readAsync: file => readFile(file, "utf8")
+    readErrorHandler: (file, error) => {
+        console.error(`Error reading file ${file}: ${error.message}`);
+    },
+    parseErrorHandler: (file, error) => {
+        throw new Error(`Error parsing file ${file}: ${error.message}`);
+    },
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "java-model",
   "description": "Java model",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "author": "Pascal",
   "main": "dist/index.js",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -64,8 +64,14 @@ import {
 } from "./Project";
 import { PrimitiveType } from "./PrimitiveType";
 
-type Sync = { files: string[]; read: (file: string) => string };
-type Async = { files: string[]; readAsync: (file: string) => Promise<string> };
+type FileErrorHandler = (file: string, e: any) => void;
+type FilesParser = {
+  files: Iterable<string>
+  readErrorHandler?: FileErrorHandler,
+  parseErrorHandler?: FileErrorHandler,
+}
+type Sync = FilesParser & { read: (file: string) => string };
+type Async = FilesParser & { readAsync: (file: string) => Promise<string> };
 
 export function parse(sources: string[]): Project;
 export function parse(input: Sync): Project;
@@ -83,21 +89,32 @@ export function parse(
 }
 
 function parseSync(input: Sync) {
-  return new Project(
-    input.files.map((file) => {
+  const compilationUnits: CompilationUnit[] = [];
+  for (const file of input.files) {
       let source;
       try {
         source = input.read(file);
       } catch (e) {
-        errorRead(file, e);
+        if (input.readErrorHandler) {
+          input.readErrorHandler(file, e);
+        }
+        else {
+          errorRead(file, e);
+        }
+        continue;
       }
       try {
-        return parseFile(source);
+        compilationUnits.push(parseFile(source));
       } catch (e) {
-        errorParse(file, e);
+        if (input.parseErrorHandler) {
+          input.parseErrorHandler(file, e);
+        }
+        else {
+          errorParse(file, e);
+        }
       }
-    })
-  );
+  }
+  return new Project(compilationUnits);
 }
 
 async function parseAsync(input: Async) {
@@ -107,12 +124,23 @@ async function parseAsync(input: Async) {
     try {
       source = await input.readAsync(file);
     } catch (e) {
-      errorRead(file, e);
+        if (input.readErrorHandler) {
+          input.readErrorHandler(file, e);
+        }
+        else {
+          errorRead(file, e);
+        }
+        continue;
     }
     try {
       compilationUnits.push(parseFile(source));
     } catch (e) {
-      errorParse(file, e);
+        if (input.parseErrorHandler) {
+          input.parseErrorHandler(file, e);
+        }
+        else {
+          errorParse(file, e);
+        }
     }
   }
   return new Project(compilationUnits);


### PR DESCRIPTION
Enhance error handling in Sync and Async parsers with customizable error handlers.
The primary purpose of this PR is to enable parsing a partial project even if not all files are accessible or parseable.
Also, using `Iterator` instead of `array` doesn't break compatibility and enables using a `Set<string>` of paths.