### PR TITLE
Support generic string sources to provide custom context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,97 @@ record B(String s) {
 enum C { C1, C2 }
 ```
 
+### Array of Sources
+
 ```typescript
 import { readFileSync } from "node:fs";
 import { parse } from "java-model";
 
-const project = parse({
-    files: ["input.java"],
-    read: (file) => readFileSync(file, "utf8")
-});
+const files = ["input.java"];
+const sources = files.map((file) => readFileSync(file, "utf8"));
+const project = parse(sources);
 
 project.visitTypes((type) => {
    console.log(type.name);
    console.log(type.qualifiedName);
    console.log(type.properties());
 });
+```
+
+### Provide a Read Function
+
+```typescript
+import { readFileSync } from "node:fs";
+import { parse } from "java-model";
+
+const project = parse({
+    files: ["input.java"],
+    read: file => readFileSync(file, "utf8")
+});
+
+project.visitTypes(type => {
+   console.log(type.name);
+   console.log(type.qualifiedName);
+   console.log(type.properties());
+});
+```
+
+### Provide an Async Read Function
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { parse } from "java-model";
+
+const project = parse({
+    files: ["input.java"],
+    readAsync: file => readFile(file, "utf8")
+});
+
+project.visitTypes(type => {
+   console.log(type.name);
+   console.log(type.qualifiedName);
+   console.log(type.properties());
+});
+```
+
+### Custom Source Object
+
+```typescript
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { parse } from "java-model";
+
+class CustomSourceFile extends String {
+    sourcePath: string;
+    author: string;
+    teamId: number;
+
+    constructor(source: string, sourcePath: string, author: string, teamId: number) {
+        super(source);
+        this.sourcePath = sourcePath;
+        this.author = author;
+        this.teamId = teamId;
+    }
+}
+
+const project = parse({
+    files: ["input.java"],
+    read: file => {
+        const content = readFileSync(file, "utf8");
+        const sourcePath = path.resolve(file);
+        const author = "John Doe";
+        const teamId = 12345;
+        return new CustomSourceFile(content, sourcePath, author, teamId);
+    }
+});
+
+project.compilationUnits.forEach((compilationUnit) => {
+    const codeSource = compilationUnit.context.source as CustomSourceFile;
+    console.log(`Source Path: ${codeSource.sourcePath}`);
+    console.log(`Author: ${codeSource.author}`);
+    console.log(`Team ID: ${codeSource.teamId}`);
+});
+
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "java-model",
   "description": "Java model",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "author": "Pascal",
   "main": "dist/index.js",

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -2,7 +2,7 @@ import {
   AnnotationContext,
   AnnotationTypeDeclarationContext,
   ClassDeclarationContext,
-  CompilationUnitContext,
+  CompilationUnitContext as CompilationUnitContextBase,
   ConstructorDeclarationContext,
   ElementValueContext,
   EnumConstantContext,
@@ -23,6 +23,9 @@ import { Expression } from "./Expression";
 import { PrimitiveType } from "./PrimitiveType";
 import { resolve } from "./resolve";
 import { TypeReference } from "./TypeReference";
+
+
+type CompilationUnitContext = CompilationUnitContextBase & { source?: String };
 
 export class Project {
   private compilationUnits: CompilationUnit[];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -68,8 +68,8 @@ type Sync<S extends String = string> = { files: string[]; read: (file: string) =
 type Async<S extends String = string> = { files: string[]; readAsync: (file: string) => Promise<S> };
 
 export function parse(sources: string[]): Project;
-export function parse(input: Sync): Project;
-export function parse(input: Async): Promise<Project>;
+export function parse<S extends String = string>(input: Sync<S>): Project;
+export function parse<S extends String = string>(input: Async<S>): Promise<Project>;
 export function parse(
   input: string[] | Sync | Async
 ): Project | Promise<Project> {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -64,8 +64,8 @@ import {
 } from "./Project";
 import { PrimitiveType } from "./PrimitiveType";
 
-type Sync = { files: string[]; read: (file: string) => string };
-type Async = { files: string[]; readAsync: (file: string) => Promise<string> };
+type Sync<S extends String = string> = { files: string[]; read: (file: string) => S };
+type Async<S extends String = string> = { files: string[]; readAsync: (file: string) => Promise<S> };
 
 export function parse(sources: string[]): Project;
 export function parse(input: Sync): Project;
@@ -128,7 +128,7 @@ function errorParse(file: string, e: any): never {
   throw e;
 }
 
-function parseFile(source: string): CompilationUnit {
+function parseFile(source: String): CompilationUnit {
   const dummyProject = {} as Project;
   const dummyParent = {} as Model;
 
@@ -174,7 +174,7 @@ function parseFile(source: string): CompilationUnit {
 
   const visitor = createVisitor({
     visitCompilationUnit(ctx) {
-      compilationUnit = new CompilationUnit(dummyProject, ctx);
+      compilationUnit = new CompilationUnit(dummyProject, Object.assign(ctx, { source }));
       visitor.visitChildren(ctx);
     },
     visitPackageDeclaration(ctx) {
@@ -382,7 +382,7 @@ function parseFile(source: string): CompilationUnit {
     }
   });
 
-  const ast = parseAst(source);
+  const ast = parseAst(source.toString());
   visitor.visit(ast);
 
   return compilationUnit!;


### PR DESCRIPTION
Useful for code that is read from remote origins, such as GitHub, to provide additional information about the code source.